### PR TITLE
Make assertClose work with floating point numbers

### DIFF
--- a/src/ImpTestCase.nut
+++ b/src/ImpTestCase.nut
@@ -116,7 +116,7 @@ local ImpTestCase = class {
    */
   function assertClose(expected, actual, maxDiff, message = "Expected value: %s±%s, got: %s") {
     this.assertions++;
-    if (math.abs(expected - actual) > maxDiff) {
+    if (math.fabs(expected - actual) > maxDiff) {
       throw format(message, expected + "", maxDiff + "", actual + "");
     }
   }


### PR DESCRIPTION
Issue : assertClose() does not support float ranges

changed the file "impttestcase.nut" , "function assertClose"  modified with   "math.fabs" instead "math.abs"
 to accommodate    float value 