### PR TITLE
Fix promise-lib-4.0.0 naming

### DIFF
--- a/index.nut
+++ b/index.nut
@@ -22,7 +22,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-#require "promise.class.nut:4.0.0"
+#require "Promise.lib.nut:4.0.0"
 #require "JSONEncoder.class.nut:2.0.0"
 
 // impUnit module


### PR DESCRIPTION
Promise lib name changed from promise.class.nut:4.0.0 to Promise.lib.nut:4.0.0